### PR TITLE
usb-pd: Derive Debug and Format where applicable

### DIFF
--- a/usb-pd/src/header.rs
+++ b/usb-pd/src/header.rs
@@ -6,8 +6,8 @@ use {
 };
 
 bitfield! {
-    #[derive(Clone, Copy, PartialEq, Eq)]
-    pub struct Header(pub u16): FromRaw, IntoRaw {
+    #[derive(Clone, Copy, PartialEq, Eq, Format)]
+    pub struct Header(pub u16): Debug, FromRaw, IntoRaw {
         pub extended: bool @ 15,
         pub num_objects: u8 [get usize] @ 12..=14,
         pub message_id: u8 @ 9..=11,
@@ -38,7 +38,7 @@ impl Header {
     }
 }
 
-#[derive(Format)]
+#[derive(Debug, Format)]
 pub enum SpecificationRevision {
     R1_0,
     R2_0,
@@ -66,13 +66,13 @@ impl From<SpecificationRevision> for u8 {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Format)]
 pub enum MessageType {
     Control(ControlMessageType),
     Data(DataMessageType),
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Format)]
 pub enum ControlMessageType {
     GoodCRC = 0b0_0001,
     GotoMin = 0b0_0010,
@@ -133,7 +133,7 @@ impl From<u8> for ControlMessageType {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Format)]
 pub enum DataMessageType {
     SourceCapabilities = 0b0_0001,
     Request = 0b0_0010,

--- a/usb-pd/src/lib.rs
+++ b/usb-pd/src/lib.rs
@@ -27,7 +27,7 @@ impl core::ops::Not for CcPin {
     }
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub enum PowerRole {
     Source,
     Sink,
@@ -51,7 +51,7 @@ impl From<PowerRole> for bool {
     }
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub enum DataRole {
     Ufp,
     Dfp,

--- a/usb-pd/src/message.rs
+++ b/usb-pd/src/message.rs
@@ -13,7 +13,7 @@ use {
     heapless::Vec,
 };
 
-#[derive(Clone, Format)]
+#[derive(Debug, Clone, Format)]
 pub enum Message {
     Accept,
     Reject,

--- a/usb-pd/src/pdo.rs
+++ b/usb-pd/src/pdo.rs
@@ -4,7 +4,7 @@ use {
     proc_bitfield::bitfield,
 };
 
-#[derive(Clone, Copy, Format)]
+#[derive(Clone, Copy, Debug, Format)]
 pub enum PowerDataObject {
     FixedSupply(FixedSupply),
     Battery(Battery),
@@ -14,14 +14,14 @@ pub enum PowerDataObject {
 
 bitfield! {
     #[derive(Clone, Copy, PartialEq, Eq)]
-    pub struct PowerDataObjectRaw(pub u32): FromRaw, IntoRaw {
+    pub struct PowerDataObjectRaw(pub u32): Debug, FromRaw, IntoRaw {
         pub kind: u8 @ 30..=31,
     }
 }
 
 bitfield! {
     #[derive(Clone, Copy, PartialEq, Eq, Format)]
-    pub struct FixedSupply(pub u32): FromRaw, IntoRaw {
+    pub struct FixedSupply(pub u32): Debug, FromRaw, IntoRaw {
         /// Fixed supply
         pub kind: u8 @ 30..=31,
         /// Dual-role power
@@ -49,7 +49,7 @@ bitfield! {
 
 bitfield! {
     #[derive(Clone, Copy, PartialEq, Eq, Format)]
-    pub struct Battery(pub u32): FromRaw, IntoRaw {
+    pub struct Battery(pub u32): Debug, FromRaw, IntoRaw {
         /// Battery
         pub kind: u8 @ 30..=31,
         /// Maximum Voltage in 50mV units
@@ -63,7 +63,7 @@ bitfield! {
 
 bitfield! {
     #[derive(Clone, Copy, PartialEq, Eq, Format)]
-    pub struct VariableSupply(pub u32): FromRaw, IntoRaw {
+    pub struct VariableSupply(pub u32): Debug, FromRaw, IntoRaw {
         /// Variable supply (non-battery)
         pub kind: u8 @ 30..=31,
         /// Maximum Voltage in 50mV units
@@ -75,7 +75,7 @@ bitfield! {
     }
 }
 
-#[derive(Clone, Copy, Format)]
+#[derive(Clone, Copy, Debug, Format)]
 pub enum AugmentedPowerDataObject {
     SPR(SPRProgrammablePowerSupply),
     EPR(EPRAdjustableVoltageSupply),
@@ -83,7 +83,7 @@ pub enum AugmentedPowerDataObject {
 
 bitfield! {
     #[derive(Clone, Copy, PartialEq, Eq, Format)]
-    pub struct AugmentedPowerDataObjectRaw(pub u32): FromRaw, IntoRaw {
+    pub struct AugmentedPowerDataObjectRaw(pub u32): Debug, FromRaw, IntoRaw {
         /// Augmented power data object
         pub kind: u8 @ 30..=31,
         pub supply: u8 @ 28..=29,
@@ -93,7 +93,7 @@ bitfield! {
 
 bitfield! {
     #[derive(Clone, Copy, PartialEq, Eq, Format)]
-    pub struct SPRProgrammablePowerSupply(pub u32): FromRaw, IntoRaw {
+    pub struct SPRProgrammablePowerSupply(pub u32): Debug, FromRaw, IntoRaw {
         /// Augmented power data object
         pub kind: u8 @ 30..=31,
         /// SPR programmable power supply
@@ -110,7 +110,7 @@ bitfield! {
 
 bitfield! {
     #[derive(Clone, Copy, PartialEq, Eq, Format)]
-    pub struct EPRAdjustableVoltageSupply(pub u32): FromRaw, IntoRaw {
+    pub struct EPRAdjustableVoltageSupply(pub u32): Debug, FromRaw, IntoRaw {
         /// Augmented power data object
         pub kind: u8 @ 30..=31,
         /// EPR adjustable voltage supply
@@ -127,7 +127,7 @@ bitfield! {
 
 bitfield! {
     #[derive(Clone, Copy, PartialEq, Eq, Format)]
-    pub struct FixedVariableRequestDataObject(pub u32): FromRaw, IntoRaw {
+    pub struct FixedVariableRequestDataObject(pub u32): Debug, FromRaw, IntoRaw {
         /// Valid range 1..=14
         pub object_position: u8 @ 28..=31,
         pub giveback_flag: bool @ 27,
@@ -147,7 +147,7 @@ impl FixedVariableRequestDataObject {
     }
 }
 
-#[derive(Clone, Copy, Format)]
+#[derive(Clone, Copy, Debug, Format)]
 pub enum VDMCommandType {
     InitiatorREQ,
     ResponderACK,
@@ -179,7 +179,7 @@ impl From<u8> for VDMCommandType {
     }
 }
 
-#[derive(Clone, Copy, Format)]
+#[derive(Clone, Copy, Debug, Format)]
 pub enum VDMCommand {
     DiscoverIdentity,
     DiscoverSVIDS,
@@ -222,7 +222,7 @@ impl From<u8> for VDMCommand {
     }
 }
 
-#[derive(Clone, Copy, Format)]
+#[derive(Clone, Copy, Debug, Format)]
 pub enum VDMType {
     Unstructured,
     Structured,
@@ -246,7 +246,7 @@ impl From<bool> for VDMType {
     }
 }
 
-#[derive(Clone, Copy, Format)]
+#[derive(Clone, Copy, Debug, Format)]
 pub enum VDMHeader {
     Structured(VDMHeaderStructured),
     Unstructured(VDMHeaderUnstructured),
@@ -254,7 +254,7 @@ pub enum VDMHeader {
 
 bitfield! {
     #[derive(Clone, Copy, PartialEq, Eq, Format)]
-    pub struct VDMHeaderRaw(pub u32): FromRaw, IntoRaw {
+    pub struct VDMHeaderRaw(pub u32): Debug, FromRaw, IntoRaw {
         /// VDM Standard or Vendor ID
         pub standard_or_vid: u16 @ 16..=31,
         /// VDM Type (Unstructured/Structured)
@@ -270,7 +270,7 @@ impl VDMHeaderRaw {
 
 bitfield! {
     #[derive(Clone, Copy, PartialEq, Eq, Format)]
-    pub struct VDMHeaderStructured(pub u32): FromRaw, IntoRaw {
+    pub struct VDMHeaderStructured(pub u32): Debug, FromRaw, IntoRaw {
         /// VDM Standard or Vendor ID
         pub standard_or_vid: u16 @ 16..=31,
         /// VDM Type (Unstructured/Structured)
@@ -294,7 +294,7 @@ impl VDMHeaderStructured {
 
 bitfield! {
     #[derive(Clone, Copy, PartialEq, Eq, Format)]
-    pub struct VDMHeaderUnstructured(pub u32): FromRaw, IntoRaw {
+    pub struct VDMHeaderUnstructured(pub u32): Debug, FromRaw, IntoRaw {
         /// VDM Standard or Vendor ID
         pub standard_or_vid: u16 @ 16..=31,
         /// VDM Type (Unstructured/Structured)
@@ -312,7 +312,7 @@ impl VDMHeaderUnstructured {
 
 bitfield! {
     #[derive(Clone, Copy, PartialEq, Eq, Format)]
-    pub struct VDMIdentityHeader(pub u32): FromRaw, IntoRaw {
+    pub struct VDMIdentityHeader(pub u32): Debug, FromRaw, IntoRaw {
         /// Host data capable
         pub host_data: bool @ 31,
         /// Device data capable
@@ -338,7 +338,7 @@ impl VDMIdentityHeader {
 
 bitfield! {
     #[derive(Clone, Copy, PartialEq, Eq, Format)]
-    pub struct DisplayPortCapabilities(pub u32): FromRaw, IntoRaw {
+    pub struct DisplayPortCapabilities(pub u32): Debug, FromRaw, IntoRaw {
         /// UFP_D Pin Assignments Supported
         pub ufp_d_pin_assignments: u8 @ 16..=23,
         /// DFP_D Pin Assignments Supported


### PR DESCRIPTION
Derive Debug to make it easier to for development in an std environment. Also derive Format on a few more types for debugging with defmt in no_std.