### PR TITLE
Gracefully handle unknown pdo aspects when parsing

### DIFF
--- a/usb-pd/src/messages/mod.rs
+++ b/usb-pd/src/messages/mod.rs
@@ -49,10 +49,16 @@ impl Message {
                                 0b01 => {
                                     AugmentedPowerDataObject::EPR(EPRAdjustableVoltageSupply(pdo.0))
                                 }
-                                _ => unreachable!(),
+                                _ => {
+                                    warn!("Unknown AugmentedPowerDataObject supply");
+                                    AugmentedPowerDataObject::Unknown(pdo.0)
+                                }
                             }
                         }),
-                        _ => unreachable!(),
+                        _ => {
+                            warn!("Unknown PowerDataObject kind");
+                            PowerDataObject::Unknown(pdo)
+                        }
                     })
                     .collect(),
             ),

--- a/usb-pd/src/messages/pdo.rs
+++ b/usb-pd/src/messages/pdo.rs
@@ -10,10 +10,11 @@ pub enum PowerDataObject {
     Battery(Battery),
     VariableSupply(VariableSupply),
     AugmentedPowerDataObject(AugmentedPowerDataObject),
+    Unknown(PowerDataObjectRaw),
 }
 
 bitfield! {
-    #[derive(Clone, Copy, PartialEq, Eq)]
+    #[derive(Clone, Copy, PartialEq, Eq, Format)]
     pub struct PowerDataObjectRaw(pub u32): Debug, FromRaw, IntoRaw {
         pub kind: u8 @ 30..=31,
     }
@@ -79,6 +80,7 @@ bitfield! {
 pub enum AugmentedPowerDataObject {
     SPR(SPRProgrammablePowerSupply),
     EPR(EPRAdjustableVoltageSupply),
+    Unknown(u32),
 }
 
 bitfield! {


### PR DESCRIPTION
Avoid panicing when receiving PDO's with either an unknown kind or an unknown supply in the Augmented PDO's.