### PR TITLE
Fix rust-analyzer error test

### DIFF
--- a/fusb302b/Cargo.toml
+++ b/fusb302b/Cargo.toml
@@ -9,6 +9,10 @@ homepage = "https://github.com/fmckeogh/usb-pd-rs"
 license = "MIT"
 keywords = ["nostd", "usb-pd", "driver", "embedded", "fusb302b"]
 
+[lib]
+harness = false # do not use the built-in cargo test harness -> resolve rust-analyzer errors
+test = false
+
 [dependencies]
 byteorder = { version = "1.5.0", default-features = false }
 embedded-hal-async = "1.0.0"

--- a/pd-interceptor/Cargo.toml
+++ b/pd-interceptor/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [[bin]]
+name = "pd-interceptor"
 harness = false # do not use the built-in cargo test harness -> resolve rust-analyzer errors
 test = false
 

--- a/pd-interceptor/Cargo.toml
+++ b/pd-interceptor/Cargo.toml
@@ -3,6 +3,10 @@ name = "pd-interceptor"
 version = "0.1.0"
 edition = "2021"
 
+[[bin]]
+harness = false # do not use the built-in cargo test harness -> resolve rust-analyzer errors
+test = false
+
 [dependencies]
 cortex-m = { version = "0.7.7", features = ["critical-section-single-core"] }
 cortex-m-rt = "0.7.4"

--- a/usb-pd/Cargo.toml
+++ b/usb-pd/Cargo.toml
@@ -9,6 +9,10 @@ homepage = "https://github.com/fmckeogh/usb-pd-rs"
 license = "MIT"
 keywords = ["nostd", "usb-pd", "power", "embedded"]
 
+[lib]
+harness = false # do not use the built-in cargo test harness -> resolve rust-analyzer errors
+test = false
+
 [dependencies]
 proc-bitfield = "0.4.0"
 byteorder = { version = "1.5.0", default-features = false }


### PR DESCRIPTION
When adding this project to RustRover IDE or VS Code rust-analyzer runs on project sync. It fails with this message:

```
error[E0308]: mismatched types
   --> /home/okhsunrog/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/test/src/test_result.rs:102:18
    |
101 |         None => match status.signal() {
    |                       --------------- this expression has type `Option<i32>`
102 |             Some(libc::SIGABRT) => TestResult::TrFailed,
    |                  ^^^^^^^^^^^^^ expected `i32`, found `usize`
```

I suggest adding harness = false to disable these checks.
You can take a look here, for example:
https://github.com/rust-lang/rust/issues/125714
https://github.com/esp-rs/esp-idf-template/commit/d084765561bd827d94eece13dedec90e97928e99

The commit in my branch fixes the issue.